### PR TITLE
Add specification for phpcs.xml.dist

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,6 +2,8 @@ version: 2
 plugins:
   phpcodesniffer:
     enabled: true
+    config:
+      standard: "phpcs.xml.dist"
 exclude_patterns:
   - web/themes/custom/vibe/assets/
   - web/themes/custom/vibe/css/


### PR DESCRIPTION
Hi there - Emily from Code Climate Support.

There's more in the email that I'm sending over, but here's the fix!
- Code Climate's phpcodesniffer needs this configuration to pick up your phpcs config file.

Let me know if you need anything else 👍 